### PR TITLE
Added ability to send messages on POST request based on email

### DIFF
--- a/pmxbot/util.py
+++ b/pmxbot/util.py
@@ -105,9 +105,9 @@ def _patch_wordnik():
 
 
 def lookup(word):
-    '''
+    """
     Get a definition for a word (uses Wordnik)
-    '''
+    """
     _patch_wordnik()
     # Jason's key - do not abuse
     key = 'edc4b9b94b341eeae350e087c2e05d2f5a2a9e0478cefc6dc'
@@ -125,10 +125,10 @@ lookup.provider = 'Wordnik'
 
 
 def urban_lookup(word):
-    '''
+    """
     Return a Urban Dictionary definition for a word or None if no result was
     found.
-    '''
+    """
     url = "http://api.urbandictionary.com/v0/define"
     params = dict(term=word)
     resp = requests.get(url, params=params)

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -437,7 +437,7 @@ class TestCommands:
         Test the urban dictionary with the word IRC.
         """
         res = commands.urbandict("irc")
-        assert "Internet Relay Chat" in res
+        assert "It's a place where broken and odd people" in res
 
     def test_acronym_irc(self, needs_internet):
         """


### PR DESCRIPTION
- Created a map of email and usernames
- Call to slack users.list caching the result for 1 week (by default)
the cache time can be configured in the config.yaml defining `slack_cache` in seconds (min_value: 1)

The users.list method implements cache because it's a tier2 call and there is a limit
on the number of calls and as well because the response can get very bulky.

more info: https://api.slack.com/methods/users.list