### PR TITLE
Minimal changes to get pmxbot up and running again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v1122.13.0
+==========
+
+* #99: Updated to use ``slack_sdk`` instead of ``slackclient`` and
+  ``slacker``. Restores compatibility to supported interfaces in Slack.
+
 v1122.12.0
 ==========
 

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -71,6 +71,7 @@ class Bot(pmxbot.core.Bot):
 
         self.handle_action(channel, nick, html.unescape(msg['text']))
 
+    @functools.lru_cache()
     def _get_channel_name(self, channel_id):
         return self.slack.web_client.conversations_info(
             channel=channel_id
@@ -124,7 +125,7 @@ class Bot(pmxbot.core.Bot):
             for convo in iter_cursor(convos)
         )
 
-    def get_user_mappings(self):
+    def _get_user_mappings(self):
         users = functools.partial(self.slack.web_client.users_list)
         return (
             {user['name']: user['id'] for user in user_list['members']}
@@ -133,7 +134,7 @@ class Bot(pmxbot.core.Bot):
 
     @functools.lru_cache()
     def _get_id_for_user(self, user_name):
-        return self.search_dicts(user_name, self.get_user_mappings())
+        return self.search_dicts(user_name, self._get_user_mappings())
 
     @functools.lru_cache()
     def _get_id_for_channel(self, channel_name):

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -73,9 +73,11 @@ class Bot(pmxbot.core.Bot):
 
     @functools.lru_cache()
     def _get_channel_name(self, channel_id):
-        return self.slack.web_client.conversations_info(
-            channel=channel_id
-        ).data['channel'].get('name')
+        return (
+            self.slack.web_client.conversations_info(channel=channel_id)
+            .data['channel']
+            .get('name')
+        )
 
     def _resolve_nick_standard(self, msg):
         return self.slack.web_client.users_info(user=msg['user']).data['user']['name']
@@ -141,10 +143,7 @@ class Bot(pmxbot.core.Bot):
         return self.search_dicts(channel_name.strip('#'), self._get_channel_mappings())
 
     def _expand_references(self, message):
-        resolvers = {
-            '@': self._get_id_for_user,
-            '#': self._get_id_for_channel
-        }
+        resolvers = {'@': self._get_id_for_user, '#': self._get_id_for_channel}
 
         def _expand(match):
             match_type = match.groupdict()['type']

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -18,10 +18,6 @@ log = logging.getLogger(__name__)
 SLACK_CACHE_SECONDS = 7 * 24 * 60 * 60
 
 
-class UnsuccessfulResponse(Exception):
-    pass
-
-
 def iter_cursor(callable, cursor=None):
     """
     Iterate a slack endpoint callable that uses paginated results.
@@ -31,24 +27,6 @@ def iter_cursor(callable, cursor=None):
     next_cursor = resp.data.get('response_metadata', {}).get('next_cursor')
     if next_cursor:
         yield from iter_cursor(callable, cursor=next_cursor)
-
-
-def get_ttl_hash(seconds=None):
-    """
-    Return the same value withing `seconds` time period
-
-    default seconds:
-        7 days == 7days*24hours*60min*60seconds == 604800 seconds
-
-    Cache time can be configured in config using `slack_cache` in seconds
-    """
-    if not seconds:
-        try:
-            seconds = pmxbot.config.get('slack_cache', SLACK_CACHE_SECONDS)
-        except AttributeError:
-            # whenever pmxbot doesn't have config
-            seconds = SLACK_CACHE_SECONDS
-    return round(time.time() / seconds)
 
 
 class Bot(pmxbot.core.Bot):

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -125,7 +125,7 @@ class Bot(pmxbot.core.Bot):
             channel=channel_id, text=message, thread_ts=getattr(channel, 'thread', None)
         )
 
-    @functools.lru_cache
+    @functools.lru_cache()
     def _get_channel_id(self, channel):
         # If this action was generated from a slack message event then we should have
         # the channel_id already. For other cases we need to query the Slack API to get

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -86,18 +86,15 @@ class Bot(pmxbot.core.Bot):
         self.init_schedule(self.scheduler)
         threading.Thread(target=self.run_scheduler_loop).start()
 
-        @self.slack.on("message")
-        def handle_payload(client, event):
-            self.handle_message(event)
-
+        self.slack.on("message")(self.handle_message)
         self.slack.start()
 
     def run_scheduler_loop(self):
         while True:
             self.scheduler.run_pending()
-            time.sleep(1)
+            time.sleep(0.1)
 
-    def handle_message(self, msg):
+    def handle_message(self, client, msg):
         if msg.get('type') != 'message':
             return
 
@@ -112,8 +109,7 @@ class Bot(pmxbot.core.Bot):
 
         channel_name = (
             self.slacker.conversations.info(msg['channel'])
-            .body.get('channel', {})
-            .get('name')
+            .body['channel'].get('name')
         )
         channel = core.AugmentableMessage(
             channel_name, channel_id=msg.get('channel'), thread=msg.get('thread_ts')

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,6 @@ viewer =
 
 slack =
 	slack_sdk
-	slacker
 
 irc =
 	irc >=15.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ viewer =
 
 slack =
 	# pinned due to #85
-	slackclient < 2
+	slack_sdk
 	slacker
 
 irc =

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,6 @@ viewer =
 	jinja2>=2.11.2
 
 slack =
-	# pinned due to #85
 	slack_sdk
 	slacker
 


### PR DESCRIPTION
Minimal changes to get pmxbot up and running again. Our main use case is webhooks as we've lost observability on applications as a result. This is now working as well as the common integrations (e.g. thanks and motivate)

Key changes:
- Changed the dependency to be the new name: `slack_sdk`
- Updated to use the v2 of the RTMClient
- `self.slack.server` is no longer a thing in the new client, so changed to use `self.slacker` for retrieving info on `users`/`channels` (or as they're referred to as now: `conversations`)
- Now using the web client for posting messages to slack. For this we need the channel ID rather than the channel name, so there is logic implemented to resolve this where necessary.
- Kept it simple by spawning a thread to run the scheduler rather than an asyncio loop as suggested by jaraco here: https://github.com/pmxbot/pmxbot/issues/85#issuecomment-489086969

Talking to PmxBot directly:
![image](https://user-images.githubusercontent.com/1598192/198656272-1a3eeaf8-4a2a-4e45-b5c5-3bc776fa8f5e.png)

Webhooks and scheduled messages:

![image](https://user-images.githubusercontent.com/1598192/198656597-a764c05b-e0c2-440d-baaf-92c86c94b452.png)


Responding in threads, tagging users and channels:

![image](https://user-images.githubusercontent.com/1598192/198656908-38e26f95-97b9-49f9-b570-11f99d51e62c.png)


Help docs:

![image](https://user-images.githubusercontent.com/1598192/198657514-1fd87f57-cad5-415d-9494-e3d6d5879475.png)



Some other random commands:

![image](https://user-images.githubusercontent.com/1598192/198658379-dc7bf05f-e3e4-4eec-9817-c86d629d5afa.png)


![image](https://user-images.githubusercontent.com/1598192/198660269-e496b381-80a6-4d43-9f85-f36cadacc125.png)
