### PR TITLE
Hotfix for pmxbot's name and avatar missing when posting mesages

### DIFF
--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -105,7 +105,10 @@ class Bot(pmxbot.core.Bot):
             channel_id = self._get_id_for_channel(channel)
 
         self.slack.web_client.chat_postMessage(
-            channel=channel_id, text=message, thread_ts=getattr(channel, 'thread', None)
+            channel=channel_id,
+            text=message,
+            thread_ts=getattr(channel, 'thread', None),
+            as_user=True,
         )
 
     @staticmethod


### PR DESCRIPTION
I noticed that pmxbot's name and avatar were missing from Slack. I initially thought this was Slack doing this intentionally to 'encourage' us to move towards their preferred API (socket mode). However, I found there is a flag you can set the in the API to post a message which causes the post to come from the authenticated user (PMXBOT).

Before and after:

![image](https://user-images.githubusercontent.com/1598192/198985745-ae4206d9-876d-4813-81de-83a55fb7757c.png)
