### PR TITLE
Fix to allow pmxbot to DM slack users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v1122.14.0
+==========
+
+* #103: Reintroduce the feature allowing a username or email to be used
+  in place of a channel ID, in order for pmxbot to DM users
+
 v1122.13.1
 ==========
 


### PR DESCRIPTION
Fix for: https://github.com/pmxbot/pmxbot/issues/101

Change to allow pmxbot to DM slack users by resolving a user name or email into a user ID which is then used as the channel ID.

Make requests to pmxbot webhook to test user handle (name), user email, and failure case:
(note the prefixed back slash is intentional to prevent bash from trying to read a file, this is not an character escape error in pmxbot)

![image](https://user-images.githubusercontent.com/1598192/199538370-b29d35da-d3ab-4897-8978-7fb53af66195.png)

Check the DMs make it to the user (where valid)
![image](https://user-images.githubusercontent.com/1598192/199538408-a2f7d8f8-da7e-4eeb-828d-d5819fb43c11.png)

Test `log.error` message is logged when expected:
![image](https://user-images.githubusercontent.com/1598192/199538579-75625e6b-bf8b-403d-b47b-a0bae102adee.png)
