### PR TITLE
Normalised character case when resolving channel IDs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v1122.14.1
+==========
+
+* #104: Normalised character case when resolving channel IDs to provide
+  greater flexibility on input
+
 v1122.14.0
 ==========
 


### PR DESCRIPTION
There is an issue resolving a channel ID from a user name or channel name if the case does not match. 
The code now normalises the input and dict mappings by performing a `lower()` on the strings

Testing: 

![image](https://user-images.githubusercontent.com/1598192/201741298-cee850f5-333f-416a-82e7-4abf4c9441af.png)


![image](https://user-images.githubusercontent.com/1598192/201741317-7ef640a5-1e1c-4d29-a3fa-e4ab38d7eb14.png)
